### PR TITLE
chore(deps): update NuGet dependencies

### DIFF
--- a/src/Couchbase.TravelSample.Tests/Couchbase.TravelSample.Tests.csproj
+++ b/src/Couchbase.TravelSample.Tests/Couchbase.TravelSample.Tests.csproj
@@ -9,15 +9,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.15" />        
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.22" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.22" />        
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Couchbase.TravelSample/Couchbase.TravelSample.csproj
+++ b/src/Couchbase.TravelSample/Couchbase.TravelSample.csproj
@@ -9,12 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Couchbase.Extensions.DependencyInjection" Version="3.7.0" />
-        <PackageReference Include="FluentValidation" Version="11.10.0" />
-        <PackageReference Include="CouchbaseNetClient" Version="3.7.0" />
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.15" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageReference Include="Couchbase.Extensions.DependencyInjection" Version="3.9.3" />
+        <PackageReference Include="FluentValidation" Version="12.1.1" />
+        <PackageReference Include="CouchbaseNetClient" Version="3.9.3" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.22" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Updates direct NuGet dependencies for the ASP.NET 8 Minimal API quickstart.
- Aggregates/supersedes the currently open Dependabot bumps for Couchbase, FluentValidation, Microsoft.AspNetCore.Mvc.Testing, and coverlet, while also updating other stale direct packages.
- Keeps the project on `net8.0` and preserves dotnet/NuGet package management.

Hermes Kanban task: `t_a3ee8a84`

## Updated dependencies

| Ecosystem | Dependency | Previous | Updated | Type | Notes |
|---|---:|---:|---:|---|---|
| NuGet | Couchbase.Extensions.DependencyInjection | 3.7.0 | 3.9.3 | production | Direct stable update; also aligns CouchbaseNetClient dependency. |
| NuGet | CouchbaseNetClient | 3.7.0 | 3.9.3 | production | Direct stable update; resolves the NU1902 advisory reported for 3.7.0 during restore. |
| NuGet | FluentValidation | 11.10.0 | 12.1.1 | production | Major stable update; local build/tests pass. |
| NuGet | FluentValidation.DependencyInjectionExtensions | 11.9.2 | 12.1.1 | production | Major stable update matching FluentValidation. |
| NuGet | Microsoft.AspNetCore.OpenApi | 8.0.15 | 8.0.22 | production/test | Kept on latest 8.x to respect `net8.0` and CI `setup-dotnet` 8.0.x. |
| NuGet | Swashbuckle.AspNetCore | 6.5.0 | 6.9.0 | production | Latest stable 6.x. Higher majors pull Microsoft.OpenApi v2 changes and are not a conservative drop-in for the current code. |
| NuGet | Microsoft.NET.Test.Sdk | 17.13.0 | 18.7.0 | test | Direct stable update. |
| NuGet | Microsoft.AspNetCore.Mvc.Testing | 8.0.6 | 8.0.22 | test | Kept on latest 8.x to respect `net8.0` and CI `setup-dotnet` 8.0.x. |
| NuGet | xunit.runner.visualstudio | 3.0.2 | 3.1.5 | test | Direct stable update. |
| NuGet | coverlet.collector | 6.0.2 | 10.0.1 | test | Direct stable update. |

## Validation

Commands run:

```shell
dotnet restore Couchbase.TravelSample.sln
cd src/Couchbase.TravelSample && dotnet build --configuration Debug --no-restore

# The host initially only had .NET 10 runtime, so .NET 8 SDK/runtime were installed locally under /home/ubuntu/.dotnet8 for net8 test execution.
export DOTNET_ROOT=/home/ubuntu/.dotnet8
export PATH=/home/ubuntu/.dotnet8:$PATH

# Integration-test dependency: local throwaway Couchbase container with travel-sample bucket loaded.
export DB_CONN_STR=couchbase://<local-couchbase-container-ip>
export DB_USERNAME=Administrator
export DB_PASSWORD=<local-test-password>
cd src/Couchbase.TravelSample.Tests && timeout 120 dotnet test --no-build --verbosity normal

dotnet test Couchbase.TravelSample.sln --verbosity normal
```

Outcomes:
- Restore: passed.
- Build: passed with 0 warnings and 0 errors.
- Suggested no-build test: passed, 35/35 tests.
- Full `dotnet test`: passed, 35/35 tests.

## Evidence status

| Evidence | Status | Notes |
|---|---|---|
| Browser evidence | not_applicable | This is a dependency-only PR; integration tests exercise the ASP.NET API via `WebApplicationFactory`. |
| Swagger/OpenAPI evidence | not_applicable | No running browser/API evidence requested beyond the existing integration suite. |
| Integration tests | passed | Ran against a local Couchbase Docker container with the `travel-sample` bucket loaded. |

## Risk notes

- FluentValidation is a major update (11.x to 12.x); the existing validation registration and integration tests pass unchanged.
- Swashbuckle was intentionally limited to 6.9.0. Attempting the latest 10.x line produced Microsoft.OpenApi v2 compile incompatibilities with the current code, so this PR avoids that manual migration.
- Microsoft.AspNetCore.* package updates were constrained to 8.0.22 because the repository targets `net8.0` and CI installs .NET 8.
- Existing Dependabot PRs cover subsets of these updates; this PR is an aggregate validated update rather than a duplicate of any one Dependabot PR.

## Rollback

Revert this PR to restore the previous NuGet PackageReference versions.
